### PR TITLE
Replace lens dependency with lens-simple

### DIFF
--- a/genCabal.hs
+++ b/genCabal.hs
@@ -25,8 +25,8 @@ containers = package "containers" (gtEq [0,5,5])
 rainbow :: Package
 rainbow = package "rainbow" (gtEq [0,26])
 
-lens :: Package
-lens = package "lens" (gtEq [4,9])
+lensSimple :: Package
+lensSimple = package "lens-simple" (gtEq [0,1,0,8])
 
 text :: Package
 text = package "text" (gtEq [0,11,3,1])
@@ -81,7 +81,7 @@ libPackages =
   , bytestring
   , containers
   , text
-  , lens
+  , lensSimple
   ]
 
 libDeps :: HasBuildInfo a => a

--- a/lib/Rainbox/Core.hs
+++ b/lib/Rainbox/Core.hs
@@ -11,18 +11,20 @@
 -- if their inputs don't respect particular invariants.
 module Rainbox.Core where
 
-import           Control.Lens ( (|>) , (&) , makeLenses , (<|))
-import           Control.Monad (join)
-import qualified Data.Foldable as F
-import qualified Data.Map as M
-import           Data.Monoid ((<>))
-import           Data.Sequence (Seq, ViewL (EmptyL, (:<)), viewl)
-import qualified Data.Sequence as Seq
-import           Data.Text (Text)
-import qualified Data.Text as X
+import           Control.Monad    (join)
+import qualified Data.Foldable    as F
+import qualified Data.Map         as M
+import           Data.Monoid      ((<>))
+import           Data.Sequence    (Seq, ViewL ((:<), EmptyL), viewl, (<|), (|>))
+import qualified Data.Sequence    as Seq
+import           Data.Text        (Text)
+import qualified Data.Text        as X
 import qualified Data.Traversable as T
-import           Rainbow ( Chunk , Radiant , chunk , back)
-import           Rainbow.Types (Chunk (_yarn))
+
+import           Lens.Simple      (makeLenses, (&))
+
+import           Rainbow          (Chunk, Radiant, back, chunk)
+import           Rainbow.Types    (Chunk (_yarn))
 
 -- # Alignment
 

--- a/lib/Rainbox/Tutorial.hs
+++ b/lib/Rainbox/Tutorial.hs
@@ -326,14 +326,14 @@ Rainbox does not work on infinite inputs.
 -}
 module Rainbox.Tutorial where
 
-import Control.Lens ((&))
-import Data.Foldable (toList)
-import Data.List (intersperse)
-import Data.Monoid ((<>))
-import Data.Sequence (Seq)
+import           Data.Foldable (toList)
+import           Data.List     (intersperse)
+import           Data.Monoid   ((<>))
+import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
-import Data.Text (Text)
-import qualified Data.Text as X
+import           Data.Text     (Text)
+import qualified Data.Text     as X
+import           Lens.Simple   ((&))
 import qualified Rainbow
 import qualified Rainbox
 


### PR DESCRIPTION
Considering `rainbox` is not using any advanced feature of `lens`, it is probably more appropriate, as a library, to depend on a lightweight alternative like `lens-simple`. The migration is as simple as changing a couple of imports.